### PR TITLE
Add frozenFrame clamp from 0-1000

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Configuration file: `.minecraft/config/better-firefly-bushes.properties`
 - `enableTimeBasedControl` (default: true) - Enable/disable time-based animation control
 - `animationStartTime` (default: 12000) - Minecraft time when animations start (0-24000)
 - `animationEndTime` (default: 23000) - Minecraft time when animations end (0-24000)
-- `frozenFrame` (default: 0) - Frame to display when not animating (0-9)
+- `frozenFrame` (default: 0) - Frame to display when not animating (0-1000, clamped to available frames)
 
 ## Building
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,7 @@ loader_version=0.18.1
 loom_version=1.13-SNAPSHOT
 
 # Mod Properties
-mod_version=1.0.0-1.21.10
+mod_version=1.0.1-1.21.10
 maven_group=com.betterfireflybushes
 archives_base_name=better-firefly-bushes
 

--- a/src/client/java/com/betterfireflybushes/config/ModMenuIntegration.java
+++ b/src/client/java/com/betterfireflybushes/config/ModMenuIntegration.java
@@ -42,7 +42,9 @@ public class ModMenuIntegration implements ModMenuApi {
 
             general.addEntry(entryBuilder.startIntField(Text.literal("Frozen Frame"), config.getFrozenFrame())
                 .setDefaultValue(0)
-                .setTooltip(Text.literal("Frame to display when not animating (0-9)"))
+                .setMin(0)
+                .setMax(1000)
+                .setTooltip(Text.literal("Frame number to display when not animating (0-1000)."))
                 .setSaveConsumer(config::setFrozenFrame)
                 .build());
 

--- a/src/main/java/com/betterfireflybushes/config/ModConfig.java
+++ b/src/main/java/com/betterfireflybushes/config/ModConfig.java
@@ -17,12 +17,24 @@ public class ModConfig {
     @Getter @Setter private boolean enableTimeBasedControl = true;
     @Getter @Setter private int animationStartTime = 12000;
     @Getter @Setter private int animationEndTime = 23000;
-    @Getter @Setter private int frozenFrame = 0;
+    @Getter private int frozenFrame = 0;
 
     private final Path configPath;
 
     public ModConfig(Path configDir) {
         this.configPath = configDir.resolve(CONFIG_FILE_NAME);
+    }
+
+    public void setFrozenFrame(int frozenFrame) {
+        if (frozenFrame < 0) {
+            LOGGER.warn("frozenFrame value {} is below minimum (0), clamping to 0", frozenFrame);
+            this.frozenFrame = 0;
+        } else if (frozenFrame > 1000) {
+            LOGGER.warn("frozenFrame value {} is above maximum (1000), clamping to 1000", frozenFrame);
+            this.frozenFrame = 1000;
+        } else {
+            this.frozenFrame = frozenFrame;
+        }
     }
 
     /**
@@ -41,7 +53,7 @@ public class ModConfig {
             enableTimeBasedControl = Boolean.parseBoolean(props.getProperty("enableTimeBasedControl", "true"));
             animationStartTime = Integer.parseInt(props.getProperty("animationStartTime", "12000"));
             animationEndTime = Integer.parseInt(props.getProperty("animationEndTime", "23000"));
-            frozenFrame = Integer.parseInt(props.getProperty("frozenFrame", "0"));
+            setFrozenFrame(Integer.parseInt(props.getProperty("frozenFrame", "0")));
             LOGGER.info("Configuration loaded successfully from: {}", configPath);
         } catch (IOException e) {
             LOGGER.error("Failed to load configuration from: {}", configPath, e);

--- a/src/main/resources/assets/better-firefly-bushes/lang/en_us.json
+++ b/src/main/resources/assets/better-firefly-bushes/lang/en_us.json
@@ -8,5 +8,5 @@
   "config.better-fireflies.animationEndTime": "Animation End Time",
   "config.better-fireflies.animationEndTime.tooltip": "Minecraft time of day (0-24000) when fireflies stop animating. Default: 23000 (dawn)",
   "config.better-fireflies.frozenFrame": "Frozen Frame",
-  "config.better-fireflies.frozenFrame.tooltip": "Firefly bushes have 10 animation frames. This option configures the frame number (0-9) that fireflies display when they are frozen. 0=off, 9=brightest. Default: 0"
+  "config.better-fireflies.frozenFrame.tooltip": "Frame number (0-1000) that fireflies display when frozen. Values over the animation's available frames are clamped. For the default firefly texture: 0=off, 9=brightest. Default: 0"
 }


### PR DESCRIPTION
Clamp frozen frames from 0 to 1000, to support resource packs with many frames. Fixes https://github.com/zdwolfe/minecraft-better-firefly-bushes/issues/2 